### PR TITLE
fix: complete mock implementations and re-enable tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,7 @@ jobs:
       run: dotnet restore ChronoCode.sln
 
     - name: Build
-      run: dotnet build ChronoCode/ChronoCode.csproj --configuration Release --no-restore
+      run: dotnet build ChronoCode.sln --configuration Release --no-restore
+
+    - name: Test
+      run: dotnet test ChronoCode.Tests/ChronoCode.Tests.csproj --configuration Release --no-build --verbosity normal

--- a/ChronoCode.Tests/TasksControllerTests.cs
+++ b/ChronoCode.Tests/TasksControllerTests.cs
@@ -225,26 +225,67 @@ public class InMemoryOpencodeServerManager : IOpencodeServerManager
 
 public class InMemoryOpencodeClient : IOpencodeClient
 {
-    public Task<string> SendTaskAsync(string prompt, CancellationToken cancellationToken = default)
-        => Task.FromResult("Mock response");
+    public Task<string> CreateSessionAsync(string workingDirectory, CancellationToken cancellationToken = default)
+        => Task.FromResult("mock-session-id");
+    
+    public Task<string> SendPromptAsync(string sessionId, string prompt, string workingDirectory, CancellationToken cancellationToken = default)
+        => Task.FromResult("Mock AI response");
+    
+    public Task<string> SendPromptWithStreamingAsync(string sessionId, string prompt, string workingDirectory, Func<string, Task> onChunk, CancellationToken cancellationToken = default)
+        => Task.FromResult("Mock streaming response");
+    
+    public Task<List<FileDiff>> GetSessionDiffAsync(string sessionId, string? messageId = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(new List<FileDiff>());
+    
+    public Task AbortSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+    
+    public Task<List<SessionInfo>> ListSessionsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new List<SessionInfo>());
+    
+    public Task<SessionInfo?> GetSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+        => Task.FromResult<SessionInfo?>(null);
 }
 
 public class InMemoryGitService : IGitService
 {
-    public Task<string> CloneRepositoryAsync(string repositoryUrl, string branchName)
-        => Task.FromResult("/tmp/mock/path");
-    public Task<string> CreateBranchAsync(string path, string branchName)
+    public Task<string> CloneRepositoryAsync(string repoUrl, string workspacePath)
+        => Task.FromResult("/tmp/mock/repo");
+    
+    public Task<string> CreateBranchAsync(string repoPath, string branchName, string baseBranch)
         => Task.FromResult(branchName);
-    public Task CommitChangesAsync(string path, string message)
+    
+    public Task CheckoutBranchAsync(string repoPath, string branchName)
         => Task.CompletedTask;
-    public Task<string> GetLatestCommitShaAsync(string path)
-        => Task.FromResult("abc123");
-    public Task<string> CreatePullRequestAsync(string path, string branchName, string title, string body)
-        => Task.FromResult("https://github.com/mock/pr");
+    
+    public Task<string> CommitChangesAsync(string repoPath, string message)
+        => Task.FromResult("mock-commit-sha");
+    
+    public Task PushChangesAsync(string repoPath, string remoteName = "origin")
+        => Task.CompletedTask;
+    
+    public Task<string> CreatePullRequestAsync(string repoPath, string branchName, string baseBranch, string title, string body)
+        => Task.FromResult("https://github.com/mock/pr/1");
+    
+    public Task<List<GitFileStatus>> GetChangedFilesAsync(string repoPath)
+        => Task.FromResult(new List<GitFileStatus>());
 }
 
 public class InMemoryTaskRunner : ITaskRunner
 {
-    public Task ExecuteTaskAsync(ScheduledTask task, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
+    public Task<TaskExecution> ExecuteTaskAsync(ScheduledTask task, CancellationToken cancellationToken = default)
+    {
+        var execution = new TaskExecution
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            StartedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow,
+            Status = Models.TaskStatus.Completed,
+            BranchName = "mock-branch",
+            CommitSha = "mock-sha",
+            FilesChanged = 0
+        };
+        return Task.FromResult(execution);
+    }
 }


### PR DESCRIPTION
## Summary
Fix incomplete mock implementations that were causing build failures.

### Changes
1. **InMemoryOpencodeClient**: Implements all 7 IOpencodeClient methods:
   - CreateSessionAsync
   - SendPromptAsync
   - SendPromptWithStreamingAsync
   - GetSessionDiffAsync
   - AbortSessionAsync
   - ListSessionsAsync
   - GetSessionAsync

2. **InMemoryGitService**: Implements all 7 IGitService methods:
   - CloneRepositoryAsync
   - CreateBranchAsync (with correct 3 params)
   - CheckoutBranchAsync
   - CommitChangesAsync (returns Task<string>)
   - PushChangesAsync
   - CreatePullRequestAsync (with correct 5 params)
   - GetChangedFilesAsync

3. **InMemoryTaskRunner**: Returns Task<TaskExecution> instead of Task

4. **CI**: Re-enabled full solution build and tests